### PR TITLE
Update sample-template-tag.php

### DIFF
--- a/assets/sample-template-tag.php
+++ b/assets/sample-template-tag.php
@@ -44,7 +44,7 @@ function my_twitter_feed_template_tag( $feed_config = NULL ) {
 			}
 
 			$the_feed->output .= '</ul>';
-			$the_feed->output .= '<p>More information on errors <a href="https://dev.twitter.com/docs/error-codes-responses" target="_blank" title="Twitter API Error Codes and Responses">here</a>.</p>';
+			$the_feed->output .= '<p>More information on errors <a href="https://dev.twitter.com/docs/error-codes-responses" target="_blank" rel="noopener" title="Twitter API Error Codes and Responses">here</a>.</p>';
 			*/
 
 


### PR DESCRIPTION
REL=NOOPENER IS A MUST FOR AN EXTERNAL LINK FROM AN SEO POINT OF VIEW AS GOOGLE GIVES IMPORTANCE TO SECURITY AND PERFORMANCE ISSUES.